### PR TITLE
Image for rultor updated

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,7 +1,7 @@
 architect:
   - hizmailovich
 docker:
-  image: l3r8y/rultor-image:1.0.3
+  image: yegor256/rultor-image:1.22.0
 merge:
   script:
     - "mvn clean install --errors --batch-mode"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the Docker image used in the .rultor.yml file. 

### Detailed summary
- Updated the Docker image from "l3r8y/rultor-image:1.0.3" to "yegor256/rultor-image:1.22.0"
- No other notable changes were made.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->